### PR TITLE
ssl: Allow NULL encryption cipher (authentication only).

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -77,7 +77,7 @@
 #include <openssl/ssl.h>
 #include <openssl/err.h>
 
-#define SSL_DEFAULT_CIPHERS     "HIGH:!aNULL:!MD5"
+#define SSL_DEFAULT_CIPHERS     "HIGH:eNULL:!aNULL:!MD5"
 #define SSL_PROTOCOLS (NGX_SSL_SSLv3|NGX_SSL_TLSv1 |NGX_SSL_TLSv1_1|NGX_SSL_TLSv1_2)
 
 /* ssl error strings */


### PR DESCRIPTION
Typically SSL is used to encrypt messages, but in aprsc the purpose of SSL is to authenticate amateur radio operators. We don't need encryption to perform this authentication. Further, amateur radio operators connecting via amateur radio networks are not allowed to encrypt their messages. This patch allows aprsc to accept SSL connections without encryption, using SSL only for secure authentication.

I tested by sending Xastir connections through stunnel to aprsc. When stunnel default ciphers are used, it negotiates AES256-SHA. When setting stunnel `ciphers = eNULL`, it negotiates NULL-SHA. Analyzing a packet capture confirmed the contents of the APRS packet were sent in clear text after an authentication header.
