### PR TITLE
uplink: Less blocking of worker threads

### DIFF
--- a/src/uplink.c
+++ b/src/uplink.c
@@ -745,6 +745,8 @@ void uplink_thread(void *asdf)
 					has_uplink++;
 				avail_uplink++;
 			}
+			if (uplink_shutting_down)
+				break;
 		}
 		
 		if (avail_uplink && !has_uplink) {
@@ -778,6 +780,9 @@ void uplink_thread(void *asdf)
 			}
 		}
 		
+		if (uplink_shutting_down)
+			break;
+
 		/* sleep for 4 seconds between successful rounds */
 		for (rc = 0; (!uplink_shutting_down) && rc < 4000/200; rc++)
 			if (poll(NULL, 0, 200) == -1 && errno != EINTR)

--- a/src/worker.h
+++ b/src/worker.h
@@ -297,7 +297,6 @@ struct client_t {
 
 	int    fd;
 	
-	int    uplink_index; /* uplink array index */
 	int    portnum;
 	int    listener_id;  /* which listener is this client connected to */
 	time_t connect_time;/* Time of connection, wallclock real time */


### PR DESCRIPTION
A combination of uplink being closed, and a new one being created at the same time, could block the worker for a while. Do not hold uplink_client_mutex while establishing a connection.

Improve shutdown time when attempting to create uplinks.