### PR TITLE
config: Add DisallowIgateCall to drop packets by igate call or Q construct

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ ubuntu-latest, ubuntu-22.04 ]
+        os: [ ubuntu-latest ]
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -324,6 +324,12 @@ following callsigns are dropped by default: N0CALL* NOCALL* SERVER*
 
     DisallowSourceCall P1RAT* P?ROT*
 
+DisallowIgateCall makes the server drop packets which have the given callsign
+as one of the igate/receiver callsigns appearing after the Q construct in the
+path, even though they were injected at a different server.
+
+    DisallowIgateCall P1RAT* P?ROT*
+
 
 ### Environment ###
 

--- a/src/config.c
+++ b/src/config.c
@@ -67,6 +67,7 @@ char *new_fake_version;
 
 char **disallow_srccall_glob, **new_disallow_srccall_glob;
 char **disallow_login_glob, **new_disallow_login_glob;
+char **disallow_igate_glob, **new_disallow_igate_glob;
 
 int listen_low_ports = 0; /* do we have any < 1024 ports set? need POSIX capabilities? */
 
@@ -188,6 +189,7 @@ static struct cfgcmd cfg_cmds[] = {
 	{ "fake_version",	_CFUNC_ do_string,	&new_fake_version	},
 	{ "disallowlogincall",	_CFUNC_ do_string_array,	&new_disallow_login_glob	},
 	{ "disallowsourcecall",	_CFUNC_ do_string_array,	&new_disallow_srccall_glob	},
+	{ "disallowigatecall",	_CFUNC_ do_string_array,	&new_disallow_igate_glob	},
 	{ NULL,			NULL,			NULL			}
 };
 
@@ -1405,7 +1407,19 @@ int read_config(void)
 		disallow_login_glob = NULL;
 		free_string_array(o);
 	}
-	
+
+	if (new_disallow_igate_glob) {
+		char **o = disallow_igate_glob;
+		disallow_igate_glob = new_disallow_igate_glob;
+		new_disallow_igate_glob = NULL;
+		if (o)
+			free_string_array(o);
+	} else if (disallow_igate_glob) {
+		char **o = disallow_igate_glob;
+		disallow_igate_glob = NULL;
+		free_string_array(o);
+	}
+
 	/* validate uplink config: if there is a single 'multiro' connection
 	 * configured, all of the uplinks must be 'multiro'
 	 */
@@ -1534,6 +1548,10 @@ void free_config(void)
 	if (disallow_login_glob) {
 		free_string_array(disallow_login_glob);
 		disallow_login_glob = NULL;
+	}
+	if (disallow_igate_glob) {
+		free_string_array(disallow_igate_glob);
+		disallow_igate_glob = NULL;
 	}
 }
 

--- a/src/config.h
+++ b/src/config.h
@@ -106,6 +106,7 @@ extern char *fake_version;
 
 extern char **disallow_srccall_glob;
 extern char **disallow_login_glob;
+extern char **disallow_igate_glob;
 
 extern char def_cfgfile[];
 extern char *cfgfile;

--- a/src/configure
+++ b/src/configure
@@ -4040,9 +4040,12 @@ fi
 
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for macOS signature of pthread_setname_np" >&5
 printf %s "checking for macOS signature of pthread_setname_np... " >&6; }
+save_CFLAGS="$CFLAGS"
+CFLAGS="$CFLAGS -Werror"
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
+        #define _GNU_SOURCE
         #include <pthread.h>
         void check_pthread_setname_np() {
             pthread_setname_np("test");
@@ -4070,6 +4073,7 @@ printf "%s\n" "no" >&6; }
 esac
 fi
 rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+CFLAGS="$save_CFLAGS"
 
 
 

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -103,8 +103,17 @@ dnl)
 AC_CHECK_LIB(pthread, pthread_setname_np, AC_DEFINE([HAVE_PTHREAD_SETNAME_NP], [], [pthread_setname_np available]))
 
 AC_MSG_CHECKING([for macOS signature of pthread_setname_np])
+dnl _GNU_SOURCE must be defined before including pthread.h so that glibc
+dnl exposes the (two-argument) Linux prototype - just like hlog.c does.
+dnl Without it the function is undeclared on glibc and the single-argument
+dnl call below compiles as an implicit declaration, falsely detecting the
+dnl macOS signature. -Werror makes the wrong number of arguments fatal so
+dnl the test result is reliable.
+save_CFLAGS="$CFLAGS"
+CFLAGS="$CFLAGS -Werror"
 AC_COMPILE_IFELSE(
     [AC_LANG_PROGRAM([[
+        #define _GNU_SOURCE
         #include <pthread.h>
         void check_pthread_setname_np() {
             pthread_setname_np("test");
@@ -114,6 +123,7 @@ AC_COMPILE_IFELSE(
      AC_DEFINE([HAVE_PTHREAD_SETNAME_NP_MACOS], [1], [pthread_setname_np has macOS signature])],
     [AC_MSG_RESULT(no)]
 )
+CFLAGS="$save_CFLAGS"
 
 dnl Solaris resolver solution:
 AC_SUBST(LIBGETNAMEINFO)

--- a/src/incoming.c
+++ b/src/incoming.c
@@ -81,7 +81,8 @@ const char *inerr_labels[] = {
 	"inerr_empty",
 	"disallow_srccall",
 	"disallow_dx",
-	"disallow_msg_dst"
+	"disallow_msg_dst",
+	"disallow_igatecall"
 };
 
 #define incoming_strerror(i) ((i <= 0 && i >= INERR_MIN) ? inerr_labels[i * -1] : inerr_labels[0])
@@ -679,8 +680,38 @@ int check_path_calls(const char *via_start, const char *path_end)
 	}
 	
 	//hlog(LOG_DEBUG, "check_path_calls returning %d", calls);
-	
+
 	return calls;
+}
+
+/*
+ *	Check the comma-delimited fields starting at the Q construct (q_start)
+ *	and ending at path_end against the disallow_igate_glob set. This covers
+ *	both the Q construct itself (e.g. qAY) and the igate/receiver callsigns
+ *	following it, so a configured glob can drop based on either.
+ *	q_start points to the 'q' of the Q construct, path_end to the ':'.
+ *	Returns -1 if a disallowed field is found, 0 otherwise.
+ */
+
+static int check_igate_calls(const char *q_start, const char *path_end)
+{
+	const char *p = q_start;
+	const char *e;
+
+	while (p < path_end) {
+		e = p;
+		/* find end of this path callsign */
+		while (*e != ',' && e < path_end)
+			e++;
+
+		/* check the field (the q construct itself, or an igate call) */
+		if (check_call_glob_match(disallow_igate_glob, p, e-p))
+			return -1;
+
+		p = e + 1;
+	}
+
+	return 0;
 }
 
 /*
@@ -951,7 +982,12 @@ int incoming_parse(struct worker_t *self, struct client_t *c, char *s, int len)
 		hlog(LOG_DEBUG, "%s/%s: q construct drop: %d", c->addr_rem, c->username, path_append_len);
 		return path_append_len;
 	}
-	
+
+	/* check if any of the igate callsigns after the Q construct are disallowed */
+	if (disallow_igate_glob && q_start != NULL && q_start >= s && q_start < path_end
+	    && check_igate_calls(q_start, path_end) == -1)
+		return INERR_DIS_IGATECALL; /* disallowed igate callsign */
+
 	/* get a packet buffer */
 	int new_len;
 	if (q_replace)

--- a/src/login.c
+++ b/src/login.c
@@ -365,15 +365,30 @@ int login_handler(struct worker_t *self, struct client_t *c, int l4proto, char *
 				break;
 			}
 
-			if ((i+2 < argc && strcasecmp(argv[i+2], "filter") == 0) || (i+2 >= argc)) {
+			const char *app_name = argv[i+1];
+			const char *app_ver = (i+2 < argc) ? argv[i+2] : "";
+			/* If the software name and version are not separated by a
+			 * space, the filter/udp keyword (or nothing) ends up as the
+			 * version number.
+			 */
+			int ver_missing = (i+2 >= argc) || (strcasecmp(app_ver, "filter") == 0);
+
+			/* set app name and version, which also determines whether
+			 * this is a known-broken client running in quirks mode
+			 */
+			login_set_app_name(c, app_name, app_ver);
+			i += 2;
+
+			/* reject logins with a missing version number, unless the
+			 * client is in quirks mode (known-broken software, which
+			 * often does not send a proper version number)
+			 */
+			if (ver_missing && !c->quirks_mode) {
 				hlog(LOG_WARNING, "%s/%s: vers app '%s' ver '%s': software name and version are not separated by a space",
-					c->addr_rem, username, argv[i+1], argv[i+2]);
+					c->addr_rem, username, app_name, app_ver);
 				rc = client_printf(self, c, "# Invalid login: software name and version are not separated by a space\r\n");
 				goto failed_login;
 			}
-
-			login_set_app_name(c, argv[i+1], (i+2 < argc) ? argv[i+2] : "");
-			i += 2;
 
 		} else if (strcasecmp(argv[i], "udp") == 0) {
 			if (++i >= argc) {

--- a/src/worker.h
+++ b/src/worker.h
@@ -224,8 +224,9 @@ struct client_heard_t {
 #define INERR_DIS_SRCCALL		-33
 #define INERR_DIS_DX			-34
 #define INERR_DIS_MSG_DST		-35
+#define INERR_DIS_IGATECALL		-36
 
-#define INERR_MIN			-35	/* MINIMUM VALUE FOR INERR, GROW WHEN NEEDED! */
+#define INERR_MIN			-36	/* MINIMUM VALUE FOR INERR, GROW WHEN NEEDED! */
 /* WHEN ADDING STUFF HERE, REMEMBER TO UPDATE inerr_labels IN incoming.c. Thanks! */
 #define INERR_BUCKETS			(INERR_MIN*-1 + 1)
 

--- a/tests/cfg-aprsc/basic
+++ b/tests/cfg-aprsc/basic
@@ -87,4 +87,5 @@ FileLimit        10000
 # Additional callsigns blocked
 DisallowSourceCall	N7CALL N8CALL* *DROP DRG* OH?DRU O*ZZZ
 DisallowLoginCall	LOGINA LOGINB *prrej mi*rej sufre*
+DisallowIgateCall	IGDROP IG8CALL* *IGREJ IGR* OH?IGA qAY
 

--- a/tests/t/11misc-drops.t
+++ b/tests/t/11misc-drops.t
@@ -96,6 +96,14 @@ my @pkts = (
 	"GLDROP>DST,DIGI,qAR,$login:>should drop, GLDROP as source callsign matches *DROP",
 	"DRGLOB>DST,DIGI,qAR,$login:>should drop, DRGLOB as source callsign matches DRG*",
 	"OH7DRU>DST,DIGI,qAR,$login:>should drop, OH7DRU as source callsign matches OH?DRUP",
+	# disallowed igate/receiver callsigns after the Q construct: IGDROP IG8CALL* *IGREJ IGR* OH?IGA
+	"SRC>DST,DIGI,qAR,IGDROP:>should drop, IGDROP as igate callsign matches IGDROP",
+	"SRC>DST,DIGI,qAR,IG8CALL-1:>should drop, IG8CALL-1 as igate callsign matches IG8CALL*",
+	"SRC>DST,DIGI,qAR,XIGREJ:>should drop, XIGREJ as igate callsign matches *IGREJ",
+	"SRC>DST,DIGI,qAR,IGROTHER:>should drop, IGROTHER as igate callsign matches IGR*",
+	"SRC>DST,DIGI,qAR,OH2IGA:>should drop, OH2IGA as igate callsign matches OH?IGA",
+	# disallowed Q construct itself
+	"SRC>DST,DIGI,qAY,IGTEST:>should drop, qAY Q construct matches disallowed qAY",
 	# DX spots
 	"SRC>DST,DIGI,qAR,$login:DX de FOO: BAR - should drop",
 	# Disallowed message recipients, status messages and such


### PR DESCRIPTION
Add a DisallowIgateCall option (config.c/config.h), accepting a glob list
like DisallowSourceCall and DisallowLoginCall. incoming.c checks every
comma-delimited field from the Q construct (q_start) to path_end against
disallow_igate_glob after q_process, so a configured glob can drop based on
the igate/receiver callsigns or on the Q construct itself (e.g. qAY).

Add drop tests in tests/t/11misc-d